### PR TITLE
Prepare for Atom 1.13 (stop using ::shadow)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   "repository": "https://github.com/lee-dohm/white-cursor",
   "license": "MIT",
   "engines": {
-    "atom": ">=0.174.0 <2.0.0"
+    "atom": ">=1.13 <2.0.0"
   }
 }

--- a/styles/white-cursor.less
+++ b/styles/white-cursor.less
@@ -6,6 +6,6 @@
   cursor: -webkit-image-set(@ibeam-1x 1x, @ibeam-2x 2x) 5 8, text;
 }
 
-.white-cursor .editor-contents, .white-cursor atom-text-editor::shadow .editor-contents--private {
+.white-cursor .editor-contents, .white-cursor atom-text-editor.editor .editor-contents--private {
   .white-cursor-image;
 }


### PR DESCRIPTION
Modifies the LESS file to fit the new guidelines for Atom 1.13 (now in beta).

More info here: http://blog.atom.io/2016/11/14/removing-shadow-dom-boundary-from-text-editor-elements.html

The changes here came from an Atom Deprecation Cop warning. Here's [the pre-filled issue](https://github.com/lee-dohm/white-cursor/issues/new?title=Deprecated%20selector%20in%20%60white-cursor/styles/white-cursor.less%60&body=In%20%60white-cursor/styles/white-cursor.less%60:%20%0A%0AStarting%20from%20Atom%20v1.13.0,%20the%20contents%20of%20%60atom-text-editor%60%20elements%20are%20no%20longer%20encapsulated%20within%20a%20shadow%20DOM%20boundary.%20This%20means%20you%20should%20stop%20using%20%60:host%60%20and%20%60::shadow%60%20pseudo-selectors,%20and%20prepend%20all%20your%20syntax%20selectors%20with%20%60syntax--%60.%20To%20prevent%20breakage%20with%20existing%20style%20sheets,%20Atom%20will%20automatically%20upgrade%20the%20following%20selectors:%0A%0A*%20%60.white-cursor%20.editor-contents,%0A.white-cursor%20atom-text-editor::shadow%20.editor-contents--private%60%20=%3E%20%60.white-cursor%20.editor-contents,%0A.white-cursor%20atom-text-editor.editor%20.editor-contents--private%60%0A%0AAutomatic%20translation%20of%20selectors%20will%20be%20removed%20in%20a%20few%20release%20cycles%20to%20minimize%20startup%20time.%20Please,%20make%20sure%20to%20upgrade%20the%20above%20selectors%20as%20soon%20as%20possible.) it encourages a user to open.